### PR TITLE
GTMのスニペットを出力するHelperを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--require spec_helper
+--require rspec-power_assert

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in gtmsnippet.gemspec
+gemspec
+
+gem "rake", "~> 13.0"
+
+gem "rspec", "~> 3.0"
+
+gem "rspec-power_assert"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+PATH
+  remote: .
+  specs:
+    gtmsnippet (0.1.0)
+      activesupport
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.5.0)
+    i18n (1.9.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.15.0)
+    power_assert (1.1.7)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.2)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-power_assert (1.1.0)
+      power_assert (~> 1.1.0)
+      rspec (>= 2.14)
+    rspec-support (3.10.3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  gtmsnippet!
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  rspec-power_assert
+
+BUNDLED WITH
+   2.2.32

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Gtmsnippet
+
+A Ruby helper that provides Google Tag Manager Snippet.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'gtmsnippet', github: "colorfulcompany/gtmsnippet"
+```
+
+## Usage
+
+```bash
+export GTM_CONTAINER=GTM-1234567
+export GTM_AUTH=xxx
+export GTM_PREVIEW=env-1
+```
+
+```ruby
+require "gtmsnippet"
+
+include Gtmsnippet::Helper 
+```
+
+```html
+<head>
+    <%= gtm_head_snippet %>
+</head>
+<body>
+    <%= gtm_body_snippet %>
+</body>
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/colorfulcompany/gtmsnippet.
+
+## References
+
+- [koic/gtm_rails: Simply embed Google Tag Manager container snippet into Rails application](https://github.com/koic/gtm_rails)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "gtmsnippet"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/gtmsnippet.gemspec
+++ b/gtmsnippet.gemspec
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "lib/gtmsnippet/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "gtmsnippet"
+  spec.version = Gtmsnippet::VERSION
+  spec.authors = ["cc-kawakami"]
+  spec.email = ["kawakami-moeki@colorfulcompany.co.jp"]
+
+  spec.summary = "A Ruby helper that provides Google Tag Manager Snippet."
+  spec.description = "A Ruby helper that provides Google Tag Manager Snippet."
+  spec.required_ruby_version = ">= 2.6.0"
+
+  spec.metadata["source_code_uri"] = "https://github.com/colorfulcompany/gtmsnippet"
+
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    end
+  end
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "activesupport"
+end

--- a/lib/gtmsnippet.rb
+++ b/lib/gtmsnippet.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "gtmsnippet/version"
+require_relative "gtmsnippet/helper"
+
+module Gtmsnippet
+  class Error < StandardError; end
+  # Your code goes here...
+end

--- a/lib/gtmsnippet/configuration.rb
+++ b/lib/gtmsnippet/configuration.rb
@@ -1,0 +1,27 @@
+module Gtmsnippet
+  class Configuration
+    attr_accessor :container, :auth, :preview
+
+    #
+    # @param [String] container
+    # @param [String] auth
+    # @param [String] preview
+    #
+    def initialize(
+        container: ENV["GTM_CONTAINER"],
+        auth: ENV["GTM_AUTH"],
+        preview: ENV["GTM_PREVIEW"]
+      )
+      @container = container
+      @auth = auth
+      @preview = preview
+    end
+
+    #
+    # @return [Boolean]
+    #
+    def disabled?
+      container.nil? || auth.nil? || preview.nil?
+    end
+  end
+end

--- a/lib/gtmsnippet/helper.rb
+++ b/lib/gtmsnippet/helper.rb
@@ -1,0 +1,33 @@
+require "active_support/core_ext/string/strip"
+require "active_support/core_ext/string/output_safety"
+require_relative "./configuration"
+
+module Gtmsnippet
+  module Helper
+    #
+    # @return [String]
+    #
+    def gtm_head_snippet(config: Gtmsnippet::Configuration.new)
+      return "" if config.disabled?
+
+      <<-HTML.strip_heredoc.html_safe
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=#{config.auth}&gtm_preview=#{config.preview}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','#{config.container}');</script>
+        <!-- End Google Tag Manager -->
+      HTML
+    end
+
+    #
+    # @return [String]
+    #
+    def gtm_body_snippet(config: Gtmsnippet::Configuration.new)
+      return "" if config.disabled?
+
+      <<-HTML.strip_heredoc.html_safe
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=#{config.container}&gtm_auth=#{config.auth}&gtm_preview=#{config.preview}&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+      HTML
+    end
+  end
+end

--- a/lib/gtmsnippet/version.rb
+++ b/lib/gtmsnippet/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Gtmsnippet
+  VERSION = "0.1.0"
+end

--- a/spec/gtmsnippet/configuration_spec.rb
+++ b/spec/gtmsnippet/configuration_spec.rb
@@ -1,0 +1,32 @@
+require_relative "../../lib/gtmsnippet/configuration"
+
+RSpec.describe Gtmsnippet::Configuration do
+  describe "#disabled?" do
+    context "when all values are not set" do
+      config = Gtmsnippet::Configuration.new(
+        container: nil,
+        auth: nil,
+        preview: nil
+      )
+      it_is_asserted_by { config.disabled? }
+    end
+
+    context "when all values are set" do
+      config = Gtmsnippet::Configuration.new(
+        container: "GTM-1234567",
+        auth: "xxx",
+        preview: "env-1"
+      )
+      it_is_asserted_by { config.disabled? == false }
+    end
+
+    context "when container is not set" do
+      config = Gtmsnippet::Configuration.new(
+        container: nil,
+        auth: "xxx",
+        preview: "env-1"
+      )
+      it_is_asserted_by { config.disabled? }
+    end
+  end
+end

--- a/spec/gtmsnippet/helper_spec.rb
+++ b/spec/gtmsnippet/helper_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Gtmsnippet::Helper do
+  include Gtmsnippet::Helper
+
+  describe "#gtm_head_snippet" do
+    it {
+      output = gtm_head_snippet(config: Gtmsnippet::Configuration.new(
+        container: "GTM-1234567",
+        auth: "xxx",
+        preview: "env-1"
+      ))
+
+      is_asserted_by { output.include?("GTM-1234567") }
+    }
+  end
+
+  describe "#gtm_head_snippet" do
+    it {
+      output = gtm_body_snippet(config: Gtmsnippet::Configuration.new(
+        container: "GTM-1234567",
+        auth: "xxx",
+        preview: "env-1"
+      ))
+
+      is_asserted_by { output.include?("GTM-1234567") }
+    }
+
+    context "when config is disabled" do
+      it {
+        output = gtm_body_snippet(config: Gtmsnippet::Configuration.new(
+          container: nil,
+          auth: nil,
+          preview: nil
+        ))
+
+        is_asserted_by { output.empty? }
+      }
+    end
+  end
+end

--- a/spec/gtmsnippet_spec.rb
+++ b/spec/gtmsnippet_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Gtmsnippet do
+  it "has a version number" do
+    expect(Gtmsnippet::VERSION).not_to be nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "gtmsnippet"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
## 利用例
- Hanami: [Comparing master...pull-req/improve-gtm-snippet · colorfulcompany/rakusate](https://github.com/colorfulcompany/rakusate/compare/pull-req/improve-gtm-snippet?expand=1)
- Rails: [Comparing main...pull-req/improve-gtm-snippet-structures · colorfulcompany/myhome-i](https://github.com/colorfulcompany/myhome-i/compare/pull-req/improve-gtm-snippet-structures?expand=1)

## 設計
- 

## レビューしてほしいこと
- configuration 周りの設計について

## 参考
- [koic/gtm_rails: Simply embed Google Tag Manager container snippet into Rails application](https://github.com/koic/gtm_rails)